### PR TITLE
Implement patient sorting, randomisation and reset endpoints

### DIFF
--- a/PatientApp.Api/Controllers/PatientsController.cs
+++ b/PatientApp.Api/Controllers/PatientsController.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PatientApp.Shared;
+
+namespace PatientApp.Api.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class PatientsController : ControllerBase
+{
+    private readonly StudyContext _db;
+
+    public PatientsController(StudyContext db)
+    {
+        _db = db;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Patient>>> GetPatients([FromQuery] string? sort, [FromQuery] bool desc = false)
+    {
+        IQueryable<Patient> query = _db.Patients;
+
+        if (!string.IsNullOrWhiteSpace(sort))
+        {
+            var property = typeof(Patient).GetProperty(sort,
+                BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+            if (property is not null)
+            {
+                query = desc
+                    ? query.OrderByDescending(p => EF.Property<object>(p, property.Name))
+                    : query.OrderBy(p => EF.Property<object>(p, property.Name));
+            }
+        }
+
+        return await query.ToListAsync();
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<Patient>> GetPatient(Guid id)
+    {
+        var patient = await _db.Patients.FindAsync(id);
+        return patient is not null ? Ok(patient) : NotFound();
+    }
+
+    [HttpPost("{id:guid}/randomise")]
+    public async Task<ActionResult<Patient>> Randomise(Guid id, [FromBody] RandomiseRequest request)
+    {
+        var patient = await _db.Patients.FindAsync(id);
+        if (patient is null)
+        {
+            return NotFound();
+        }
+
+        if (patient.Pill != Pill.None)
+        {
+            return BadRequest("Patient already randomised");
+        }
+
+        patient.Initials = request.Initials;
+        patient.AllocatedAt = DateTime.UtcNow;
+
+        var redCount = await _db.Patients.CountAsync(p => p.Pill == Pill.Red);
+        var blueCount = await _db.Patients.CountAsync(p => p.Pill == Pill.Blue);
+
+        patient.Pill = redCount >= 2
+            ? Pill.Blue
+            : blueCount >= 2
+                ? Pill.Red
+                : (Random.Shared.Next(2) == 0 ? Pill.Red : Pill.Blue);
+
+        await _db.SaveChangesAsync();
+        return Ok(patient);
+    }
+
+    public record RandomiseRequest(string Initials);
+}

--- a/PatientApp.Api/Controllers/ResetController.cs
+++ b/PatientApp.Api/Controllers/ResetController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using PatientApp.Shared;
+
+namespace PatientApp.Api.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class ResetController : ControllerBase
+{
+    private readonly StudyContext _db;
+
+    public ResetController(StudyContext db)
+    {
+        _db = db;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Reset()
+    {
+        foreach (var p in _db.Patients)
+        {
+            p.Pill = Pill.None;
+            p.Initials = string.Empty;
+            p.AllocatedAt = null;
+        }
+
+        await _db.SaveChangesAsync();
+        return Ok();
+    }
+}

--- a/PatientApp.Api/Program.cs
+++ b/PatientApp.Api/Program.cs
@@ -1,10 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using PatientApp.Api;
-using PatientApp.Shared;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 builder.Services.AddDbContext<StudyContext>(opt =>
@@ -26,13 +26,6 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-app.MapGet("/patients", async (StudyContext db) => await db.Patients.ToListAsync())
-   .WithName("GetPatients");
-
-app.MapGet("/patients/{id:guid}", async (Guid id, StudyContext db) =>
-    await db.Patients.FindAsync(id) is Patient patient
-        ? Results.Ok(patient)
-        : Results.NotFound())
-   .WithName("GetPatientById");
+app.MapControllers();
 
 app.Run();


### PR DESCRIPTION
## Summary
- allow sorting patient list via /patients?sort=field&desc=true using MVC controller
- add /patients/{id}/randomise to allocate pills and update initials
- add /reset endpoint to clear allocations

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891bf17d3808332957657c7329d12e8