### PR TITLE
Add xUnit tests for PatientApp API

### DIFF
--- a/PatientApp.Api.Tests/PatientApp.Api.Tests.csproj
+++ b/PatientApp.Api.Tests/PatientApp.Api.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PatientApp.Api\PatientApp.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PatientApp.Api.Tests/PatientsControllerTests.cs
+++ b/PatientApp.Api.Tests/PatientsControllerTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PatientApp.Api;
+using PatientApp.Api.Controllers;
+using PatientApp.Shared;
+using Xunit;
+
+public class PatientsControllerTests
+{
+    private static StudyContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<StudyContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new StudyContext(options);
+    }
+
+    [Fact]
+    public async Task GetPatients_ReturnsPatientsSortedByProperty()
+    {
+        using var context = CreateContext();
+        context.Patients.AddRange(
+            new Patient { Id = Guid.NewGuid(), Initials = "BB", DateOfBirth = new DateOnly(1980,1,1), AddedAt = DateTime.UtcNow },
+            new Patient { Id = Guid.NewGuid(), Initials = "AA", DateOfBirth = new DateOnly(1980,1,1), AddedAt = DateTime.UtcNow },
+            new Patient { Id = Guid.NewGuid(), Initials = "CC", DateOfBirth = new DateOnly(1980,1,1), AddedAt = DateTime.UtcNow }
+        );
+        await context.SaveChangesAsync();
+        var controller = new PatientsController(context);
+
+        var result = await controller.GetPatients("Initials");
+
+        Assert.Equal(new[] { "AA", "BB", "CC" }, result.Value!.Select(p => p.Initials));
+    }
+
+    [Fact]
+    public async Task GetPatients_ReturnsDescendingWhenRequested()
+    {
+        using var context = CreateContext();
+        context.Patients.AddRange(
+            new Patient { Id = Guid.NewGuid(), Initials = "AA", DateOfBirth = new DateOnly(1980,1,1), AddedAt = DateTime.UtcNow },
+            new Patient { Id = Guid.NewGuid(), Initials = "BB", DateOfBirth = new DateOnly(1980,1,1), AddedAt = DateTime.UtcNow }
+        );
+        await context.SaveChangesAsync();
+        var controller = new PatientsController(context);
+
+        var result = await controller.GetPatients("Initials", desc: true);
+
+        Assert.Equal(new[] { "BB", "AA" }, result.Value!.Select(p => p.Initials));
+    }
+
+    [Fact]
+    public async Task GetPatient_ReturnsNotFound_WhenPatientMissing()
+    {
+        using var context = CreateContext();
+        var controller = new PatientsController(context);
+
+        var result = await controller.GetPatient(Guid.NewGuid());
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetPatient_ReturnsPatient_WhenExists()
+    {
+        using var context = CreateContext();
+        var patient = new Patient
+        {
+            Id = Guid.NewGuid(),
+            Initials = "AA",
+            DateOfBirth = new DateOnly(1980,1,1),
+            AddedAt = DateTime.UtcNow
+        };
+        context.Patients.Add(patient);
+        await context.SaveChangesAsync();
+        var controller = new PatientsController(context);
+
+        var result = await controller.GetPatient(patient.Id);
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var returned = Assert.IsType<Patient>(okResult.Value);
+        Assert.Equal(patient.Id, returned.Id);
+    }
+
+    [Fact]
+    public async Task Randomise_AssignsBlueWhenTwoRedsExist()
+    {
+        using var context = CreateContext();
+        context.Patients.AddRange(
+            new Patient { Id = Guid.NewGuid(), Initials = "RR1", Pill = Pill.Red, DateOfBirth = new DateOnly(1980,1,1), AddedAt = DateTime.UtcNow },
+            new Patient { Id = Guid.NewGuid(), Initials = "RR2", Pill = Pill.Red, DateOfBirth = new DateOnly(1980,1,1), AddedAt = DateTime.UtcNow }
+        );
+        var target = new Patient { Id = Guid.NewGuid(), DateOfBirth = new DateOnly(1980,1,1), AddedAt = DateTime.UtcNow };
+        context.Patients.Add(target);
+        await context.SaveChangesAsync();
+        var controller = new PatientsController(context);
+
+        var result = await controller.Randomise(target.Id, new PatientsController.RandomiseRequest("XY"));
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var updated = Assert.IsType<Patient>(okResult.Value);
+        Assert.Equal(Pill.Blue, updated.Pill);
+        Assert.Equal("XY", updated.Initials);
+        Assert.NotNull(updated.AllocatedAt);
+    }
+
+    [Fact]
+    public async Task Randomise_ReturnsBadRequest_WhenAlreadyRandomised()
+    {
+        using var context = CreateContext();
+        var patient = new Patient
+        {
+            Id = Guid.NewGuid(),
+            Initials = "AA",
+            Pill = Pill.Red,
+            DateOfBirth = new DateOnly(1980,1,1),
+            AddedAt = DateTime.UtcNow,
+            AllocatedAt = DateTime.UtcNow
+        };
+        context.Patients.Add(patient);
+        await context.SaveChangesAsync();
+        var controller = new PatientsController(context);
+
+        var result = await controller.Randomise(patient.Id, new PatientsController.RandomiseRequest("BB"));
+
+        var badResult = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("Patient already randomised", badResult.Value);
+    }
+}
+

--- a/PatientApp.Api.Tests/ResetControllerTests.cs
+++ b/PatientApp.Api.Tests/ResetControllerTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PatientApp.Api;
+using PatientApp.Api.Controllers;
+using PatientApp.Shared;
+using Xunit;
+
+public class ResetControllerTests
+{
+    private static StudyContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<StudyContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new StudyContext(options);
+    }
+
+    [Fact]
+    public async Task Reset_ClearsPatients()
+    {
+        using var context = CreateContext();
+        context.Patients.AddRange(
+            new Patient { Id = Guid.NewGuid(), Initials = "AA", Pill = Pill.Red, DateOfBirth = new DateOnly(1980,1,1), AddedAt = DateTime.UtcNow, AllocatedAt = DateTime.UtcNow },
+            new Patient { Id = Guid.NewGuid(), Initials = "BB", Pill = Pill.Blue, DateOfBirth = new DateOnly(1980,1,1), AddedAt = DateTime.UtcNow, AllocatedAt = DateTime.UtcNow }
+        );
+        await context.SaveChangesAsync();
+        var controller = new ResetController(context);
+
+        var result = await controller.Reset();
+
+        Assert.IsType<OkResult>(result);
+        var patients = context.Patients.ToList();
+        Assert.All(patients, p =>
+        {
+            Assert.Equal(Pill.None, p.Pill);
+            Assert.Equal(string.Empty, p.Initials);
+            Assert.Null(p.AllocatedAt);
+        });
+    }
+}
+

--- a/PatientApp.Api.Tests/StudyContextTests.cs
+++ b/PatientApp.Api.Tests/StudyContextTests.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using PatientApp.Api;
+using Xunit;
+
+public class StudyContextTests
+{
+    [Fact]
+    public void OnModelCreating_SeedsPatients()
+    {
+        var options = new DbContextOptionsBuilder<StudyContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var context = new StudyContext(options);
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+
+        Assert.Equal(4, context.Patients.Count());
+    }
+}
+

--- a/PatientApp.sln
+++ b/PatientApp.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PatientApp", "PatientApp\Pa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PatientApp.Shared", "PatientApp.Shared\PatientApp.Shared.csproj", "{AD86F2B9-6159-4929-BFED-A1E8174177C9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PatientApp.Api.Tests", "PatientApp.Api.Tests\PatientApp.Api.Tests.csproj", "{941CEE9C-B409-43A9-B670-FD51AC3F51A4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{AD86F2B9-6159-4929-BFED-A1E8174177C9}.Release|x64.Build.0 = Release|Any CPU
 		{AD86F2B9-6159-4929-BFED-A1E8174177C9}.Release|x86.ActiveCfg = Release|Any CPU
 		{AD86F2B9-6159-4929-BFED-A1E8174177C9}.Release|x86.Build.0 = Release|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Debug|x64.Build.0 = Debug|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Debug|x86.Build.0 = Debug|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Release|x64.ActiveCfg = Release|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Release|x64.Build.0 = Release|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Release|x86.ActiveCfg = Release|Any CPU
+		{941CEE9C-B409-43A9-B670-FD51AC3F51A4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add PatientApp.Api.Tests xUnit project referencing PatientApp.Api
- test PatientsController query sorting, retrieval and randomisation rules
- test ResetController reset behaviour and StudyContext seeding

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891c8e3365883329fd06d5aa629f12b