### PR TITLE
Add API client and patient service

### DIFF
--- a/PatientApp/Program.cs
+++ b/PatientApp/Program.cs
@@ -1,4 +1,5 @@
 using PatientApp.Components;
+using PatientApp.Services;
 
 namespace PatientApp
 {
@@ -11,6 +12,13 @@ namespace PatientApp
             // Add services to the container.
             builder.Services.AddRazorComponents()
                 .AddInteractiveServerComponents();
+
+            builder.Services.AddHttpClient<ApiClient>(client =>
+            {
+                var baseUrl = builder.Configuration["ApiBaseUrl"] ?? "http://localhost";
+                client.BaseAddress = new Uri(baseUrl);
+            });
+            builder.Services.AddScoped<PatientService>();
 
             var app = builder.Build();
 

--- a/PatientApp/Services/ApiClient.cs
+++ b/PatientApp/Services/ApiClient.cs
@@ -1,0 +1,37 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace PatientApp.Services;
+
+public class ApiClient
+{
+    private readonly HttpClient _httpClient;
+
+    public ApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public Task<T?> GetAsync<T>(string uri)
+        => _httpClient.GetFromJsonAsync<T>(uri);
+
+    public async Task<T?> PostAsync<T>(string uri, object? data = null)
+    {
+        HttpResponseMessage response = data is null
+            ? await _httpClient.PostAsync(uri, null)
+            : await _httpClient.PostAsJsonAsync(uri, data);
+
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<T>();
+    }
+
+    public async Task PostAsync(string uri, object? data = null)
+    {
+        HttpResponseMessage response = data is null
+            ? await _httpClient.PostAsync(uri, null)
+            : await _httpClient.PostAsJsonAsync(uri, data);
+
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/PatientApp/Services/PatientService.cs
+++ b/PatientApp/Services/PatientService.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using PatientApp.Shared;
+
+namespace PatientApp.Services;
+
+public class PatientService
+{
+    private readonly ApiClient _client;
+
+    public PatientService(ApiClient client)
+    {
+        _client = client;
+    }
+
+    public Task<IEnumerable<Patient>?> GetAsync() => _client.GetAsync<IEnumerable<Patient>>("patients");
+
+    public Task<Patient?> RandomiseAsync(Guid id, string initials)
+        => _client.PostAsync<Patient>($"patients/{id}/randomise", new { initials });
+
+    public Task ResetAsync() => _client.PostAsync("reset");
+}


### PR DESCRIPTION
## Summary
- add reusable ApiClient wrapper around HttpClient
- implement PatientService with get, randomise and reset helpers
- register ApiClient and PatientService for dependency injection

## Testing
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6891d08601f4833295c909dda3eb4ad1