### PR TITLE
Add data reset toolbar and patient list alerts

### DIFF
--- a/PatientApp.BunitTests/PatientsPageTests.cs
+++ b/PatientApp.BunitTests/PatientsPageTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
+using System.Linq;
 using Bunit;
 using PatientApp.Components.Pages;
 using PatientApp.Shared;
@@ -33,7 +34,7 @@ public class PatientsPageTests : TestContext
         var cut = RenderComponent<Patients>();
 
         // Assert
-        var button = cut.Find("button");
+        var button = cut.Find("tbody button");
         Assert.False(button.HasAttribute("disabled"));
     }
 
@@ -58,8 +59,46 @@ public class PatientsPageTests : TestContext
         var cut = RenderComponent<Patients>();
 
         // Assert
-        var button = cut.Find("button");
+        var button = cut.Find("tbody button");
         Assert.True(button.HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void Shows_message_when_all_patients_have_pills()
+    {
+        // Arrange
+        var patients = new[]
+        {
+            new Patient { Id = Guid.NewGuid(), Initials = "AA", Pill = Pill.Red },
+            new Patient { Id = Guid.NewGuid(), Initials = "BB", Pill = Pill.Blue }
+        };
+        var handler = new FakeHttpMessageHandler(JsonSerializer.Serialize(patients));
+        Services.AddSingleton(new HttpClient(handler) { BaseAddress = new Uri("http://localhost") });
+        Services.AddBlazorise().AddBootstrap5Providers().AddFontAwesomeIcons();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        // Act
+        var cut = RenderComponent<Patients>();
+
+        // Assert
+        Assert.Contains("All patients already have pills", cut.Markup);
+    }
+
+    [Fact]
+    public void Shows_message_when_no_patients_exist()
+    {
+        // Arrange
+        var patients = Array.Empty<Patient>();
+        var handler = new FakeHttpMessageHandler(JsonSerializer.Serialize(patients));
+        Services.AddSingleton(new HttpClient(handler) { BaseAddress = new Uri("http://localhost") });
+        Services.AddBlazorise().AddBootstrap5Providers().AddFontAwesomeIcons();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        // Act
+        var cut = RenderComponent<Patients>();
+
+        // Assert
+        Assert.Contains("No patients available", cut.Markup);
     }
 }
 

--- a/PatientApp/Components/Pages/Patients.razor
+++ b/PatientApp/Components/Pages/Patients.razor
@@ -5,7 +5,23 @@
 
 <PageTitle>Patients</PageTitle>
 
-<DataGrid TItem="Patient" Data="@patients" Sortable="true">
+@if (!patients.Any())
+{
+    <Alert Color="Color.Info">No patients available.</Alert>
+}
+else if (patients.All(p => p.Pill != Pill.None))
+{
+    <Alert Color="Color.Info">All patients already have pills.</Alert>
+}
+
+<DataGrid TItem="Patient" Data="@patients" Sortable="true" ShowToolbar="true">
+    <ButtonRowTemplate>
+        <Tooltip Text="Reset Data">
+            <Button Color="Color.Secondary" Size="Size.Small" Clicked="@ResetData">
+                <Icon Name="IconName.Sync" />
+            </Button>
+        </Tooltip>
+    </ButtonRowTemplate>
     <DataGridColumns>
         <DataGridColumn TItem="Patient" Field="@nameof(Patient.Initials)" Caption="Initials" />
         <DataGridColumn TItem="Patient" Field="@nameof(Patient.DateOfBirth)" Caption="Date of Birth" />
@@ -59,6 +75,16 @@
         if (result is not null)
         {
             patients = result;
+        }
+    }
+
+    private async Task ResetData()
+    {
+        var response = await Http.PostAsync("reset", null);
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await Http.GetFromJsonAsync<List<Patient>>("patients?sort=AddedAt&desc=true");
+            patients = result ?? new();
         }
     }
 


### PR DESCRIPTION
## Summary
- add toolbar Reset Data button that calls `/reset` and reloads patients
- show info alerts when all patients have pills or when list is empty
- expand bUnit tests for new alerts and adjust existing button checks

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6891f2eafc948332851d5fe0425ba62d