### PR TITLE
Configure HttpClient base address

### DIFF
--- a/PatientApp/Program.cs
+++ b/PatientApp/Program.cs
@@ -20,7 +20,11 @@ namespace PatientApp
                 .AddBootstrap5Providers()
                 .AddFontAwesomeIcons();
 
-            builder.Services.AddHttpClient();
+            var apiBaseUrl = builder.Configuration.GetValue<string>("ApiBaseUrl", "http://localhost:5189/");
+            builder.Services.AddScoped(_ => new HttpClient
+            {
+                BaseAddress = new Uri(apiBaseUrl)
+            });
 
             var app = builder.Build();
 

--- a/PatientApp/appsettings.json
+++ b/PatientApp/appsettings.json
@@ -5,5 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ApiBaseUrl": "http://localhost:5189/"
 }


### PR DESCRIPTION
## Summary
- configure HttpClient with API base URL
- add ApiBaseUrl setting for Blazor app

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6892095c9cd483328eacbaf65944d3de