### PR TITLE
Add integration tests for API endpoints

### DIFF
--- a/PatientApp.Api/Program.cs
+++ b/PatientApp.Api/Program.cs
@@ -29,3 +29,5 @@ app.UseHttpsRedirection();
 app.MapControllers();
 
 app.Run();
+
+public partial class Program { }

--- a/PatientApp.IntegrationTests/PatientApiFactory.cs
+++ b/PatientApp.IntegrationTests/PatientApiFactory.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using PatientApp.Api;
+using PatientApp.Shared;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace PatientApp.IntegrationTests;
+
+public class PatientApiFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<StudyContext>));
+            if (descriptor is not null)
+            {
+                services.Remove(descriptor);
+            }
+
+            var root = new InMemoryDatabaseRoot();
+            services.AddDbContext<StudyContext>(options =>
+                options.UseInMemoryDatabase("IntegrationTests", root));
+
+            var sp = services.BuildServiceProvider();
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<StudyContext>();
+            db.Database.EnsureCreated();
+        });
+    }
+}

--- a/PatientApp.IntegrationTests/PatientApp.IntegrationTests.csproj
+++ b/PatientApp.IntegrationTests/PatientApp.IntegrationTests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PatientApp.Api\PatientApp.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PatientApp.IntegrationTests/PatientsEndpointTests.cs
+++ b/PatientApp.IntegrationTests/PatientsEndpointTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using PatientApp.Shared;
+
+namespace PatientApp.IntegrationTests;
+
+public class PatientsEndpointTests
+{
+    [Fact]
+    public async Task GetPatients_ReturnsSeededPatients()
+    {
+        await using var factory = new PatientApiFactory();
+        using var client = factory.CreateClient();
+
+        var patients = await client.GetFromJsonAsync<List<Patient>>("/patients");
+
+        Assert.NotNull(patients);
+        Assert.Equal(4, patients!.Count);
+    }
+
+    [Fact]
+    public async Task RandomisePatient_ReturnsAllocatedPill()
+    {
+        await using var factory = new PatientApiFactory();
+        using var client = factory.CreateClient();
+
+        var patients = await client.GetFromJsonAsync<List<Patient>>("/patients");
+        var patient = patients!.First();
+
+        var response = await client.PostAsJsonAsync($"/patients/{patient.Id}/randomise", new { Initials = "XY" });
+        response.EnsureSuccessStatusCode();
+
+        var updated = await response.Content.ReadFromJsonAsync<Patient>();
+        Assert.NotNull(updated);
+        Assert.NotEqual(Pill.None, updated!.Pill);
+        Assert.Equal("XY", updated.Initials);
+    }
+}

--- a/PatientApp.sln
+++ b/PatientApp.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PatientApp.Api.Tests", "Pat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PatientApp.BunitTests", "PatientApp.BunitTests\PatientApp.BunitTests.csproj", "{85487484-23E5-44F8-8ABB-237D82B0E357}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PatientApp.IntegrationTests", "PatientApp.IntegrationTests\PatientApp.IntegrationTests.csproj", "{63981C78-9FD5-470D-83D0-7348600CA04A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,18 @@ Global
 		{85487484-23E5-44F8-8ABB-237D82B0E357}.Release|x64.Build.0 = Release|Any CPU
 		{85487484-23E5-44F8-8ABB-237D82B0E357}.Release|x86.ActiveCfg = Release|Any CPU
 		{85487484-23E5-44F8-8ABB-237D82B0E357}.Release|x86.Build.0 = Release|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Debug|x64.Build.0 = Debug|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Debug|x86.Build.0 = Debug|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Release|x64.ActiveCfg = Release|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Release|x64.Build.0 = Release|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Release|x86.ActiveCfg = Release|Any CPU
+		{63981C78-9FD5-470D-83D0-7348600CA04A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add PatientApp.IntegrationTests project using EF in-memory
- verify Patients endpoints including randomisation
- expose Program class for use with WebApplicationFactory

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68921f4293d08332a39291c9fd34c693