### PR TITLE
Move reset button outside DataGrid toolbar

### DIFF
--- a/PatientApp/Components/Pages/Home.razor
+++ b/PatientApp/Components/Pages/Home.razor
@@ -13,15 +13,9 @@ else if (patients.All(p => p.Pill != Pill.None))
 {
     <Alert Color="Color.Info">All patients already have pills.</Alert>
 }
+<Button Color="Color.Secondary" Size="Size.Small" Clicked="@ResetData">Reset Data</Button>
 
-<DataGrid TItem="Patient" Data="@patients" Sortable="true" ShowToolbar="true">
-    <ButtonRowTemplate>
-        <Tooltip Text="Reset Data">
-            <Button Color="Color.Secondary" Size="Size.Small" Clicked="@ResetData">
-                <Icon Name="IconName.Sync" />
-            </Button>
-        </Tooltip>
-    </ButtonRowTemplate>
+<DataGrid TItem="Patient" Data="@patients" Sortable="true">
     <DataGridColumns>
         <DataGridColumn TItem="Patient" Field="@nameof(Patient.Initials)" Caption="Initials" />
         <DataGridColumn TItem="Patient" Field="@nameof(Patient.DateOfBirth)" Caption="Date of Birth" />


### PR DESCRIPTION
## Summary
- Move reset button above DataGrid and remove toolbar from Home page
- Simplify reset button text and remove tooltip and icon

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689458568b9483328d580b726021cc07