### PR TITLE
Use DataGridCommandColumn for randomise action

### DIFF
--- a/PatientApp.BunitTests/PatientsPageTests.cs
+++ b/PatientApp.BunitTests/PatientsPageTests.cs
@@ -34,7 +34,7 @@ public class PatientsPageTests : TestContext
         var cut = RenderComponent<Home>();
 
         // Assert
-        var button = cut.Find("tbody button");
+        var button = cut.FindAll("tbody button").First(b => b.TextContent.Contains("Randomise"));
         Assert.False(button.HasAttribute("disabled"));
     }
 
@@ -59,7 +59,7 @@ public class PatientsPageTests : TestContext
         var cut = RenderComponent<Home>();
 
         // Assert
-        var button = cut.Find("tbody button");
+        var button = cut.FindAll("tbody button").First(b => b.TextContent.Contains("Randomise"));
         Assert.True(button.HasAttribute("disabled"));
     }
 

--- a/PatientApp/Components/Pages/Home.razor
+++ b/PatientApp/Components/Pages/Home.razor
@@ -15,25 +15,21 @@ else if (patients.All(p => p.Pill != Pill.None))
 }
 <Button Color="Color.Secondary" Size="Size.Small" Clicked="@ResetData">Reset Data</Button>
 
-<DataGrid TItem="Patient" Data="@patients" Sortable="true">
+<DataGrid TItem="Patient" Data="@patients" Sortable="true" Editable="true">
     <DataGridColumns>
         <DataGridColumn TItem="Patient" Field="@nameof(Patient.Initials)" Caption="Initials" />
         <DataGridColumn TItem="Patient" Field="@nameof(Patient.DateOfBirth)" Caption="Date of Birth" />
         <DataGridColumn TItem="Patient" Field="@nameof(Patient.AddedAt)" Caption="Added At" />
         <DataGridColumn TItem="Patient" Field="@nameof(Patient.Pill)" Caption="Pill" />
         <DataGridColumn TItem="Patient" Field="@nameof(Patient.AllocatedAt)" Caption="Allocated At" />
-        <DataGridColumn TItem="Patient" Caption="">
-            <DisplayTemplate Context="patient">
-                @if (patient.Pill == Pill.None)
+        <DataGridCommandColumn TItem="Patient" Caption="">
+            <EditCommandTemplate Context="context">
+                @if (context.Item.Pill == Pill.None)
                 {
-                    <Tooltip Text="Randomise">
-                        <Button Color="Color.Primary" Size="Size.Small" Disabled="@IsRandomisationComplete" Clicked="@(() => OpenRandomiseModal(patient))">
-                            <Icon Name="IconName.Random" />
-                        </Button>
-                    </Tooltip>
+                    <Button Color="Color.Primary" Size="Size.Small" Disabled="@IsRandomisationComplete" Clicked="@(() => OpenRandomiseModal(context.Item))">Randomise</Button>
                 }
-            </DisplayTemplate>
-        </DataGridColumn>
+            </EditCommandTemplate>
+        </DataGridCommandColumn>
     </DataGridColumns>
 </DataGrid>
 


### PR DESCRIPTION
## Summary
- Replace display column with DataGridCommandColumn and show Randomise button without tooltip or icon
- Enable DataGrid editing to render command column
- Update tests to target Randomise button specifically

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689460246c188332887a8adc52b93539